### PR TITLE
:bug: Add ability to follow react router redirects

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,8 @@ module.exports = function (options) {
   return function (req, res, next) {
     var router = Router.create({
       location: req.url,
-      routes: options.routes
+      routes: options.routes,
+      onAbort: onAbort
     });
 
     if (!router.match(req.url)) {
@@ -103,5 +104,11 @@ module.exports = function (options) {
         }
       }
     });
+
+    function onAbort(abortReason) {
+      if (abortReason.constructor.name === 'Redirect') {
+        return res.redirect(302, router.makePath(abortReason.to, abortReason.params, abortReason.query));
+      }
+    }
   };
 };

--- a/test/fixtures/routes.js
+++ b/test/fixtures/routes.js
@@ -6,7 +6,7 @@ var RemoteFoo = require('./components/remoteFoo');
 
 var Route = Router.Route;
 var RouteHandler = Router.RouteHandler;
-
+var Redirect = Router.Redirect;
 
 var App = React.createClass({
   render: function () {
@@ -18,10 +18,11 @@ var App = React.createClass({
 
 module.exports = function () {
   return (
-    <Route handler={App}>
+    <Route name="root" handler={App}>
       <Route name='foo' path='/foo/:id' handler={routeContainer(Foo)} />
       <Route name='ping' path='/ping/:message' handler={routeContainer(Ping)} />
       <Route name='remote-foo' path='/remote-foo/:id' handler={routeContainer(RemoteFoo)} />
+      <Redirect from="/redirect" to="root" />
     </Route>
   );
 };

--- a/test/routesWithoutMartySpec.js
+++ b/test/routesWithoutMartySpec.js
@@ -54,8 +54,21 @@ describe('Routes without marty', function () {
     });
   });
 
-  function get(route) {
-    return http(server).get(route).then(function (_res) {
+  describe('when following a redirect', function () {
+    beforeEach(function () {
+      var options = {
+        followRedirect: false
+      };
+      return get('redirect', options);
+    });
+
+    it('should return a 302 status code', function () {
+      expect(res.statusCode).to.equal(302);
+    });
+  });
+
+  function get(route, options) {
+    return http(server).get(route, options).then(function (_res) {
       res = _res;
 
       return res;


### PR DESCRIPTION
Currently marty-express cannot issue a redirect set up as a react router Redirect component. 

Fix taken lovingly from @maxhoffmann at https://github.com/rackt/react-router/issues/612
