### PR TITLE
Use `console.warn` instead of `log.warn`

### DIFF
--- a/serverCookies.js
+++ b/serverCookies.js
@@ -17,7 +17,7 @@ ServerCookies.prototype = {
       return this.req.cookies[key];
     }
 
-    log.warn(
+    console.warn(
       'Warning: Could not find cookies in req. Do you have the cookie-parser middleware ' +
       '(https://www.npmjs.com/package/cookie-parser) installed?'
     );


### PR DESCRIPTION
I'm not sure if I'm missing something here, but it looks like `log` in undefined. 
Does marty-express requires an additional logging library which defines `log`?
