### PR TITLE
Allowing options.locals to be specified to pass in parameters for vie…

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,14 @@ module.exports = function (options) {
       return next();
     }
 
+    if (options.blacklist) {
+      var blacklistMatched = false;
+      options.blacklist.forEach(function(re){
+        if (re.test(req.url)) blacklistMatched = true;
+      });
+      if (blacklistMatched) return next();
+    }
+
     router.run(function (Handler, state) {
       var app = new options.application({
         req: req,

--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ module.exports = function (options) {
         .catch(onFailedToRender);
 
       function onRendered(renderResult) {
-        var locals = {};
+        var locals = options.locals || {};
 
         locals[options.body || 'body'] = renderResult.htmlBody.trim();
         locals[options.state || 'state'] = renderResult.htmlState.trim();


### PR DESCRIPTION
I was attempting to integrate react-starter (webpack) + marty isomorphism and needed to pass various parameters to the view engine (ejs) however the current build hardcoded the starting locals as {}.  This will allow passing options like so (based on the martyjs ex):

``` javascript
    app.use(require('marty-express')({
        routes: require('../app/routes'),
        application: require('../app/application'),
        locals: {
            SCRIPT_URL: scriptUrl
        },
        rendered: function (result) {
            console.log('Rendered ' + result.req.url);

            var table = new Table({
                colWidths: [30, 30, 30, 30, 40],
                head: ['Store Id', 'Fetch Id', 'Status', 'Time', 'Result']
            });

            _.each(result.diagnostics, function (diagnostic) {
                table.push([
                    diagnostic.storeId,
                    diagnostic.fetchId,
                    diagnostic.status,
                    diagnostic.time,
                    JSON.stringify(diagnostic.result || diagnostic.error || {}, null, 2)
                ]);
            });

            console.log(table.toString());
        }
    }));
```

Where the index.ejs contains:

``` html
    <script type="text/javascript" src="<%- SCRIPT_URL %>"></script>
```

In this instance the SCRIPT_URL is generated by webpack hot dev mode:

``` javascript
    var scriptUrl = publicPath + [].concat(stats.assetsByChunkName.main)[0];
```

Also adding an ability to pass a blacklist of regular expressions for things such as API.  It is very basic, feel free to improve upon it, but just an array over `/something/.test(req.url)`
